### PR TITLE
Fix new records being added on completing a campaign

### DIFF
--- a/models/campaign.go
+++ b/models/campaign.go
@@ -661,7 +661,8 @@ func CompleteCampaign(id int64, uid int64) error {
 	// Mark the campaign as complete
 	c.CompletedDate = time.Now().UTC()
 	c.Status = CampaignComplete
-	err = db.Where("id=? and user_id=?", id, uid).Save(&c).Error
+	err = db.Model(&Campaign{}).Where("id=? and user_id=?", id, uid).
+		Select([]string{"completed_date", "status"}).UpdateColumns(&c).Error
 	if err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
There were new records with name '[Deleted]' being added when a campaign was completed. This used to happen when the resource associated with a campaign (template, page, profile) was deleted before marking the campaign as completed. The save gorm call used to upsert these values and ended up adding rogue records.

PR: https://github.com/gophish/gophish/pull/2599